### PR TITLE
Reintroduce check digit calculation functionality

### DIFF
--- a/Example/SwiftUPC.xcodeproj/project.pbxproj
+++ b/Example/SwiftUPC.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03B8C58F23A012CF0038FC15 /* CheckDigitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8C58D23A012260038FC15 /* CheckDigitTests.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
@@ -27,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03B8C58D23A012260038FC15 /* CheckDigitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDigitTests.swift; sourceTree = "<group>"; };
 		250DDD076BB20501DFCDDC75 /* SwiftUPC.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = SwiftUPC.podspec; path = ../SwiftUPC.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		49FF8247ABA137FC789CA02C /* Pods-SwiftUPC_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUPC_Tests.release.xcconfig"; path = "Target Support Files/Pods-SwiftUPC_Tests/Pods-SwiftUPC_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		541C7387EF0B0085462740F7 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				03B8C58D23A012260038FC15 /* CheckDigitTests.swift */,
 				607FACEB1AFB9204008FA782 /* Tests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
@@ -336,6 +339,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				03B8C58F23A012CF0038FC15 /* CheckDigitTests.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tests/CheckDigitTests.swift
+++ b/Example/Tests/CheckDigitTests.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright © 2019 Hatched Labs. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftUPC
+
+class CheckDigitTests: XCTestCase {
+    func testCheckDigitCalculation() {
+        let codes: [(code: [Int], expectedCheckDigit: Int)] = [
+            ([1, 7, 8, 9, 0], 7),
+            ([0], 0),
+            ([], 0),
+            ([1, 2, 3], 6),
+            ([0, 0, 7, 5], 4),
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 0], 5)
+        ]
+
+        for (code, expectedCheckDigit) in codes {
+            XCTAssertEqual(expectedCheckDigit, UPCABarcodeGenerator.calculateCheckDigit(from: code))
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ let barcodeView: UPCABarcodeView // initialized somewhere in code, Storyboard, o
 barcodeView.barcodeModules = barcodeModules
 ```
 
+### Check Digit Calculation
+Check digits can be calculated for any valid UPC (or EAN13) code:
+
+```swift
+let code = [1, 2, 3]
+let checkDigit = UPCABarcodeGenerator.calculateCheckDigit(from: code)
+```
+
 ## Author
 
 [Hatched Labs](https://hatchedlabs.com)

--- a/SwiftUPC/Classes/BarcodeDrawing.swift
+++ b/SwiftUPC/Classes/BarcodeDrawing.swift
@@ -10,7 +10,7 @@ enum BarcodeDrawing {
     /// Creates a **unit** (i.e. not scaled for display) path of a bar code. Because this uses a unit module width and height of 1,
     /// it can be scaled in both the x and y directions for display.
     static func unitPathForModules(_ modules: [BarcodeModule]) -> CGPath {
-        var path = CGMutablePath()
+        let path = CGMutablePath()
         var xPos = 0
 
         for module in modules {


### PR DESCRIPTION
For some reason the changes made in [this PR](https://github.com/hatchedlabs/SwiftUPC/pull/1) are not part of our current code on `main`. Must've been a rebase mistake when preparing to open-source.

This PR reintroduces the exposed check digit calculation functionality.